### PR TITLE
Dev 2 patches

### DIFF
--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
@@ -103,7 +103,8 @@ public abstract class GsisAbstractIdentityProvider extends AbstractOAuth2Identit
 
     String username = getJsonProperty(profile, "userid");
     user.setUsername(username);
-    user.setName(getJsonProperty(profile, "firstname") + " " + getJsonProperty(profile, "lastname"));
+    user.setFirstName(getJsonProperty(profile, "firstname"));
+    user.setLastName(getJsonProperty(profile, "lastname"));
     user.setEmail("");
     user.setIdpConfig(getConfig());
     user.setIdp(this);

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
@@ -123,7 +123,7 @@ public abstract class GsisAbstractIdentityProvider extends AbstractOAuth2Identit
       profile = SimpleHttp.doGet(profileUrl, session)
           .header("Authorization", "Bearer " + accessToken)
           .asString();
-      final Map<String, String> userFields = new HashMap();
+      final Map<String, String> userFields = new HashMap<String, String>();
       SAXParserFactory parserFactory = SAXParserFactory.newInstance();
       parserFactory.setValidating(false);
       parserFactory.setXIncludeAware(false);

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
@@ -148,7 +148,7 @@ public abstract class GsisAbstractIdentityProvider extends AbstractOAuth2Identit
       jsonStringProfile += "{";
 
       int index = 0;
-      for (Map.Entry m : userFields.entrySet()) {
+      for (Map.Entry<String, String> m : userFields.entrySet()) {
         if (index > 0) {
           jsonStringProfile += ", ";
         }


### PR DESCRIPTION
Requires #7 

**No squash when merging**

---

4 warnings are left after these patches:

<details><summary>Warnings</summary>

```
[{
	"resource": "/C:/Users/xmr/Desktop/keycloak-gsis-providers/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java",
	"owner": "_generated_diagnostic_collection_name_#3",
	"code": "16777788",
	"severity": 4,
	"message": "AbstractOAuth2IdentityProvider is a raw type. References to generic type AbstractOAuth2IdentityProvider<C> should be parameterized",
	"source": "Java",
	"startLineNumber": 68,
	"startColumn": 60,
	"endLineNumber": 68,
	"endColumn": 90
},{
	"resource": "/C:/Users/xmr/Desktop/keycloak-gsis-providers/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java",
	"owner": "_generated_diagnostic_collection_name_#3",
	"code": "16777788",
	"severity": 4,
	"message": "SocialIdentityProvider is a raw type. References to generic type SocialIdentityProvider<C> should be parameterized",
	"source": "Java",
	"startLineNumber": 69,
	"startColumn": 16,
	"endLineNumber": 69,
	"endColumn": 38
},{
	"resource": "/C:/Users/xmr/Desktop/keycloak-gsis-providers/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java",
	"owner": "_generated_diagnostic_collection_name_#3",
	"code": "16777746",
	"severity": 4,
	"message": "Type safety: The constructor AbstractOAuth2IdentityProvider(KeycloakSession, OAuth2IdentityProviderConfig) belongs to the raw type AbstractOAuth2IdentityProvider. References to generic type AbstractOAuth2IdentityProvider<C> should be parameterized",
	"source": "Java",
	"startLineNumber": 74,
	"startColumn": 5,
	"endLineNumber": 74,
	"endColumn": 28
},{
	"resource": "/C:/Users/xmr/Desktop/keycloak-gsis-providers/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java",
	"owner": "_generated_diagnostic_collection_name_#3",
	"code": "16777788",
	"severity": 4,
	"message": "AbstractOAuth2IdentityProvider.Endpoint is a raw type. References to generic type AbstractOAuth2IdentityProvider<C>.Endpoint should be parameterized",
	"source": "Java",
	"startLineNumber": 197,
	"startColumn": 40,
	"endLineNumber": 197,
	"endColumn": 48
}]
```

</details>
