### PR TITLE
Backwards compatible Keycloak 26 build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,15 +34,15 @@ jobs:
           cache: maven
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           languages: 'java'
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           category: '/language:java'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 log/
 target/
+.idea/
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <main.java.package>gr.cti.nts</main.java.package>
     <keycloak.version>22.0.5</keycloak.version>
-    <lombok.version>1.18.38</lombok.version>
+    <lombok.version>1.18.44</lombok.version>
     <auto-service.version>1.1.1</auto-service.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,27 @@
     <keycloak.version>22.0.5</keycloak.version>
     <lombok.version>1.18.44</lombok.version>
     <auto-service.version>1.1.1</auto-service.version>
+    <jandex.version>3.2.0</jandex.version>
   </properties>
 
   <build>
     <finalName>${project.artifactId}-java-${build.java}-v${project.version}</finalName>
     <sourceDirectory>src/main/java</sourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+        <version>${jandex.version}</version>
+        <executions>
+          <execution>
+            <id>make-index</id>
+            <goals>
+              <goal>jandex</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <keycloak.version>22.0.5</keycloak.version>
     <lombok.version>1.18.44</lombok.version>
     <auto-service.version>1.1.1</auto-service.version>
-    <jandex.version>3.2.0</jandex.version>
+    <jandex.version>3.1.8</jandex.version>
   </properties>
 
   <build>

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
@@ -68,41 +68,46 @@ public abstract class GsisAbstractIdentityProvider
   private static final boolean USE_NEW_CONTEXT_API;
   private static final java.lang.reflect.Constructor<?> CONTEXT_CONSTRUCTOR;
   private static final java.lang.reflect.Method SET_IDP_CONFIG_METHOD;
+  private static final java.lang.reflect.Method SET_IDP_METHOD;
 
   static {
     boolean useNewApi = false;
-    java.lang.reflect.Constructor<?> constructor = null;
+    java.lang.reflect.Constructor<?> constructor;
     java.lang.reflect.Method setIdpConfigMethod = null;
+    java.lang.reflect.Method setIdpMethod = null;
 
     try {
-      // Try new API: BrokeredIdentityContext(IdentityProviderModel)
       constructor = BrokeredIdentityContext.class
-          .getConstructor(org.keycloak.models.IdentityProviderModel.class);
+        .getConstructor(org.keycloak.models.IdentityProviderModel.class);
       useNewApi = true;
       log.infof("Using new BrokeredIdentityContext(IdentityProviderModel) constructor");
     } catch (NoSuchMethodException e) {
-      // Fall back to old API: BrokeredIdentityContext(String)
       try {
         constructor = BrokeredIdentityContext.class.getConstructor(String.class);
         log.infof("Using old BrokeredIdentityContext(String) constructor");
 
-        // Check if setIdpConfig method exists
         try {
           setIdpConfigMethod = BrokeredIdentityContext.class.getMethod("setIdpConfig",
-              OAuth2IdentityProviderConfig.class);
-          log.infof("setIdpConfig method available");
-        } catch (NoSuchMethodException ex) {
-          log.infof("setIdpConfig method not available");
-        }
+            OAuth2IdentityProviderConfig.class);
+        } catch (NoSuchMethodException ex) {}
       } catch (NoSuchMethodException ex) {
-        throw new RuntimeException(
-            "Could not find any compatible BrokeredIdentityContext constructor", ex);
+        throw new RuntimeException("Could not find any compatible BrokeredIdentityContext constructor", ex);
       }
+    }
+
+    // Try to find the setIdp method (it exists in old versions, gone in new ones)
+    try {
+      setIdpMethod = BrokeredIdentityContext.class.getMethod("setIdp",
+        org.keycloak.broker.provider.IdentityProvider.class);
+      log.infof("setIdp(IdentityProvider) method available");
+    } catch (NoSuchMethodException e) {
+      log.infof("setIdp(IdentityProvider) method NOT available (Modern Keycloak)");
     }
 
     USE_NEW_CONTEXT_API = useNewApi;
     CONTEXT_CONSTRUCTOR = constructor;
     SET_IDP_CONFIG_METHOD = setIdpConfigMethod;
+    SET_IDP_METHOD = setIdpMethod;
   }
 
   public GsisAbstractIdentityProvider(KeycloakSession session,
@@ -174,11 +179,22 @@ public abstract class GsisAbstractIdentityProvider
     OAuth2IdentityProviderConfig config = getConfig();
     BrokeredIdentityContext user = createBrokeredIdentityContext(config, username);
 
+    user.setId(username);
+
     user.setUsername(username);
     user.setFirstName(firstname);
     user.setLastName(lastname);
     user.setEmail("");
-    user.setIdp(this);
+
+    if (SET_IDP_METHOD != null) {
+      try {
+        SET_IDP_METHOD.invoke(user, this);
+      } catch (Exception e) {
+        log.warn("Failed to call setIdp via reflection", e);
+      }
+    }
+    // In new versions, setIdp is not needed because the IDP is
+    // linked via the IdentityProviderModel passed in the constructor.
 
     AbstractJsonUserAttributeMapper.storeUserProfileForMapper(user, profile, config.getAlias());
 

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
@@ -70,17 +70,17 @@ public abstract class GsisAbstractIdentityProvider
     java.lang.reflect.Method setIdpConfigMethod = null;
     java.lang.reflect.Method setIdpMethod = null;
 
-    // Detect Constructor (String vs IdentityProviderModel)
     try {
-      // Keycloak 24+
-      constructor = BrokeredIdentityContext.class.getConstructor(org.keycloak.models.IdentityProviderModel.class);
+      // Try new API: BrokeredIdentityContext(IdentityProviderModel)
+      constructor = BrokeredIdentityContext.class
+        .getConstructor(org.keycloak.models.IdentityProviderModel.class);
       useNewApi = true;
-      log.infof("Detected Modern BrokeredIdentityContext(IdentityProviderModel) constructor");
+      log.infof("Using new BrokeredIdentityContext(IdentityProviderModel) constructor");
     } catch (NoSuchMethodException e) {
+      // Fall back to old API: BrokeredIdentityContext(String)
       try {
-        // Keycloak 22 and older
         constructor = BrokeredIdentityContext.class.getConstructor(String.class);
-        log.infof("Detected Legacy BrokeredIdentityContext(String) constructor");
+        log.infof("Using old BrokeredIdentityContext(String) constructor");
       } catch (NoSuchMethodException ex) {
         throw new RuntimeException("Could not find any compatible BrokeredIdentityContext constructor", ex);
       }
@@ -145,20 +145,24 @@ public abstract class GsisAbstractIdentityProvider
   private BrokeredIdentityContext createBrokeredIdentityContext(OAuth2IdentityProviderConfig config, String username) {
     try {
       BrokeredIdentityContext context;
+
       if (USE_NEW_CONTEXT_API) {
+        // New API: BrokeredIdentityContext(IdentityProviderModel)
         context = (BrokeredIdentityContext) CONTEXT_CONSTRUCTOR.newInstance(config);
       } else {
+        // Old API: BrokeredIdentityContext(String)
         context = (BrokeredIdentityContext) CONTEXT_CONSTRUCTOR.newInstance(username);
       }
 
-      // Use the reflected method to avoid signature mismatches
+      // Call setIdpConfig if the method exists
       if (SET_IDP_CONFIG_METHOD != null) {
         SET_IDP_CONFIG_METHOD.invoke(context, config);
       }
 
       return context;
     } catch (Exception e) {
-      throw new RuntimeException("Failed to create context via reflection", e);
+      throw new RuntimeException(
+        "Failed to create BrokeredIdentityContext for username: " + username, e);
     }
   }
 

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
@@ -18,6 +18,7 @@ package gr.cti.nts.keycloak.idp.social.gsis;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import javax.xml.parsers.SAXParser;
@@ -97,7 +98,7 @@ public abstract class GsisAbstractIdentityProvider
       setIdpConfigMethod = BrokeredIdentityContext.class.getMethod("setIdpConfig", org.keycloak.models.IdentityProviderModel.class);
       log.infof("Detected setIdpConfig(IdentityProviderModel) method");
     } catch (NoSuchMethodException e) {
-      log.infof("setIdpConfig method NOT available on this Keycloak version");
+      log.infof("setIdpConfig method NOT available on this Keycloak version (Modern Keycloak logic applies)");
     }
 
     // Detect setIdp(IdentityProvider) - Was removed in v25.
@@ -105,7 +106,7 @@ public abstract class GsisAbstractIdentityProvider
       setIdpMethod = BrokeredIdentityContext.class.getMethod("setIdp", org.keycloak.broker.provider.IdentityProvider.class);
       log.infof("Detected setIdp(IdentityProvider) method");
     } catch (NoSuchMethodException e) {
-      log.infof("setIdp method NOT available (Modern Keycloak logic applies)");
+      log.infof("setIdp method NOT available on this Keycloak version (Modern Keycloak logic applies)");
     }
 
     USE_NEW_CONTEXT_API = useNewApi;
@@ -369,28 +370,37 @@ public abstract class GsisAbstractIdentityProvider
 
   @Override
   public Response keycloakInitiatedBrowserLogout(KeycloakSession session,
-      UserSessionModel userSession, UriInfo uriInfo, RealmModel realm) {
-    log.infof("keycloakInitiatedBrowserLogout");
-    String logoutUrl = getLogoutUrl();
+                                                 UserSessionModel userSession, UriInfo uriInfo, RealmModel realm) {
 
-    if (logoutUrl == null || logoutUrl.trim().length() == 0) {
+    String logoutUrl = getLogoutUrl();
+    if (logoutUrl == null || logoutUrl.trim().isEmpty()) {
       return null;
     }
 
+    log.infof("Initiating GSIS logout for user session: %s", userSession.getId());
+
     String idToken = getIDTokenForLogout(session, userSession);
     String sessionId = userSession.getId();
-    UriBuilder logoutUri = UriBuilder.fromUri(logoutUrl).queryParam("state", sessionId);
+
+    UriBuilder logoutUri = UriBuilder.fromUri(logoutUrl);
+    OAuth2IdentityProviderConfig config = getConfig();
+    String redirectUri = RealmsResource.brokerUrl(uriInfo)
+      .path(IdentityBrokerService.class, "getEndpoint")
+      .path(OIDCEndpoint.class, "logoutResponse")
+      .queryParam("state", sessionId)
+      .build(realm.getName(), config.getAlias())
+      .toString();
+    UriBuilder finalUri = logoutUri.queryParam("state", sessionId);
 
     if (idToken != null) {
-      logoutUri.queryParam("id_token_hint", idToken);
+      finalUri.queryParam("id_token_hint", idToken);
     }
 
-    OAuth2IdentityProviderConfig config = getConfig();
-    String redirect = RealmsResource.brokerUrl(uriInfo)
-        .path(IdentityBrokerService.class, "getEndpoint").path(OIDCEndpoint.class, "logoutResponse")
-        .queryParam("state", sessionId).build(realm.getName(), config.getAlias()).toString();
-    logoutUri.queryParam("url", redirect);
+    finalUri.queryParam("url", redirectUri);
+    URI builtUri = finalUri.build(config.getClientId());
 
-    return Response.status(302).location(logoutUri.build(config.getClientId())).build();
+    log.infof("Logout Uri: %s", builtUri.toString());
+
+    return Response.status(302).location(builtUri).build();
   }
 }

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
@@ -30,17 +30,12 @@ import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.IdentityBrokerException;
 import org.keycloak.broker.social.SocialIdentityProvider;
 import org.keycloak.common.util.Time;
-import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
-import org.keycloak.events.EventType;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.representations.AccessTokenResponse;
-import org.keycloak.services.ErrorPage;
 import org.keycloak.services.managers.AuthenticationManager;
-import org.keycloak.services.messages.Messages;
-import org.keycloak.services.resources.IdentityBrokerService;
 import org.keycloak.services.resources.RealmsResource;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.vault.VaultStringSecret;
@@ -50,9 +45,6 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
@@ -288,44 +280,6 @@ public abstract class GsisAbstractIdentityProvider
         AbstractOAuth2IdentityProvider<OAuth2IdentityProviderConfig> provider) {
       super(callback, realm, event, provider);
     }
-
-    @GET
-    @Path("logout_response")
-    public Response logoutResponse(@QueryParam("state") String state) {
-      if (state == null) {
-        logger.error("no state parameter returned");
-        EventBuilder event = new EventBuilder(realm, session, clientConnection);
-        event.event(EventType.LOGOUT);
-        event.error(Errors.USER_SESSION_NOT_FOUND);
-
-        return ErrorPage.error(session, null, Response.Status.BAD_REQUEST,
-            Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
-      }
-
-      UserSessionModel userSession = session.sessions().getUserSession(realm, state);
-      if (userSession == null) {
-        logger.error("no valid user session");
-        EventBuilder event = new EventBuilder(realm, session, clientConnection);
-        event.event(EventType.LOGOUT);
-        event.error(Errors.USER_SESSION_NOT_FOUND);
-
-        return ErrorPage.error(session, null, Response.Status.BAD_REQUEST,
-            Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
-      }
-
-      if (userSession.getState() != UserSessionModel.State.LOGGING_OUT) {
-        logger.error("usersession in different state");
-        EventBuilder event = new EventBuilder(realm, session, clientConnection);
-        event.event(EventType.LOGOUT);
-        event.error(Errors.USER_SESSION_NOT_FOUND);
-
-        return ErrorPage.error(session, null, Response.Status.BAD_REQUEST,
-            Messages.SESSION_NOT_ACTIVE);
-      }
-
-      return AuthenticationManager.finishBrowserLogout(session, realm, userSession,
-          session.getContext().getUri(), clientConnection, headers);
-    }
   }
 
   /**
@@ -379,28 +333,34 @@ public abstract class GsisAbstractIdentityProvider
 
     log.infof("Initiating GSIS logout for user session: %s", userSession.getId());
 
-    String idToken = getIDTokenForLogout(session, userSession);
-    String sessionId = userSession.getId();
-
-    UriBuilder logoutUri = UriBuilder.fromUri(logoutUrl);
     OAuth2IdentityProviderConfig config = getConfig();
-    String redirectUri = RealmsResource.brokerUrl(uriInfo)
-      .path(IdentityBrokerService.class, "getEndpoint")
-      .path(OIDCEndpoint.class, "logoutResponse")
-      .queryParam("state", sessionId)
-      .build(realm.getName(), config.getAlias())
-      .toString();
-    UriBuilder finalUri = logoutUri.queryParam("state", sessionId);
+    String sessionId = userSession.getId();
+    String idToken = getIDTokenForLogout(session, userSession);
 
+    // Subresource dispatch on /broker/{alias}/endpoint/logout_response is broken in
+    // Keycloak 24+ for third-party providers (Quarkus REST ResourceLocatorHandler does not
+    // resolve the returned class). Finish the local Keycloak logout inline and use GSIS's
+    // url= parameter to send the user directly to the final post-logout destination.
+    Response finishResp = AuthenticationManager.finishBrowserLogout(session, realm, userSession,
+        uriInfo, session.getContext().getConnection(), session.getContext().getRequestHeaders());
+
+    String postLogoutUri = finishResp.getLocation() != null
+        ? finishResp.getLocation().toString()
+        : RealmsResource.realmBaseUrl(uriInfo).build(realm.getName()).toString();
+
+    UriBuilder logoutUri = UriBuilder.fromUri(logoutUrl).queryParam("state", sessionId);
     if (idToken != null) {
-      finalUri.queryParam("id_token_hint", idToken);
+      logoutUri.queryParam("id_token_hint", idToken);
     }
-
-    finalUri.queryParam("url", redirectUri);
-    URI builtUri = finalUri.build(config.getClientId());
+    logoutUri.queryParam("url", postLogoutUri);
+    URI builtUri = logoutUri.build(config.getClientId());
 
     log.infof("Logout Uri: %s", builtUri.toString());
 
-    return Response.status(302).location(builtUri).build();
+    Response.ResponseBuilder builder = Response.status(302).location(builtUri);
+    if (finishResp.getCookies() != null) {
+      finishResp.getCookies().values().forEach(builder::cookie);
+    }
+    return builder.build();
   }
 }

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
@@ -36,7 +36,6 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.services.managers.AuthenticationManager;
-import org.keycloak.services.resources.RealmsResource;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.vault.VaultStringSecret;
 import org.xml.sax.Attributes;
@@ -45,6 +44,8 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gr.cti.nts.keycloak.idp.social.gsis.resource.GsisLogoutResource;
+import gr.cti.nts.keycloak.idp.social.gsis.resource.GsisLogoutResourceProviderFactory;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
@@ -337,30 +338,29 @@ public abstract class GsisAbstractIdentityProvider
     String sessionId = userSession.getId();
     String idToken = getIDTokenForLogout(session, userSession);
 
-    // Subresource dispatch on /broker/{alias}/endpoint/logout_response is broken in
-    // Keycloak 24+ for third-party providers (Quarkus REST ResourceLocatorHandler does not
-    // resolve the returned class). Finish the local Keycloak logout inline and use GSIS's
-    // url= parameter to send the user directly to the final post-logout destination.
-    Response finishResp = AuthenticationManager.finishBrowserLogout(session, realm, userSession,
-        uriInfo, session.getContext().getConnection(), session.getContext().getRequestHeaders());
-
-    String postLogoutUri = finishResp.getLocation() != null
-        ? finishResp.getLocation().toString()
-        : RealmsResource.realmBaseUrl(uriInfo).build(realm.getName()).toString();
+    // Point GSIS at a RealmResourceProvider endpoint that completes the Keycloak-side logout.
+    // We can't use a @Path subresource on OIDCEndpoint here because Keycloak 24+ (Quarkus REST)
+    // doesn't route subclass @Path methods returned from IdentityBrokerService.getEndpoint(),
+    // even with a Jandex index. RealmResourceProvider gives us a first-class top-level path.
+    // NOTE: GSIS validates `url=` against the registered redirect URI. If GSIS does strict
+    // prefix-matching (only paths under /broker/{alias}/endpoint), this URL will be rejected
+    // and the user will fall back to the registered redirect URI as before. In that case,
+    // the registered URL with GSIS needs to be widened, or use the authResponse-override path.
+    String redirectUri = UriBuilder.fromUri(uriInfo.getBaseUri())
+        .path("realms").path(realm.getName())
+        .path(GsisLogoutResourceProviderFactory.ID)
+        .path(GsisLogoutResource.LOGOUT_RESPONSE_PATH)
+        .queryParam("state", sessionId)
+        .build()
+        .toString();
 
     UriBuilder logoutUri = UriBuilder.fromUri(logoutUrl).queryParam("state", sessionId);
     if (idToken != null) {
       logoutUri.queryParam("id_token_hint", idToken);
     }
-    logoutUri.queryParam("url", postLogoutUri);
+    logoutUri.queryParam("url", redirectUri);
     URI builtUri = logoutUri.build(config.getClientId());
 
-    log.infof("Logout Uri: %s", builtUri.toString());
-
-    Response.ResponseBuilder builder = Response.status(302).location(builtUri);
-    if (finishResp.getCookies() != null) {
-      finishResp.getCookies().values().forEach(builder::cookie);
-    }
-    return builder.build();
+    return Response.status(302).location(builtUri).build();
   }
 }

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/GsisAbstractIdentityProvider.java
@@ -76,32 +76,36 @@ public abstract class GsisAbstractIdentityProvider
     java.lang.reflect.Method setIdpConfigMethod = null;
     java.lang.reflect.Method setIdpMethod = null;
 
+    // Detect Constructor (String vs IdentityProviderModel)
     try {
-      constructor = BrokeredIdentityContext.class
-        .getConstructor(org.keycloak.models.IdentityProviderModel.class);
+      // Keycloak 24+
+      constructor = BrokeredIdentityContext.class.getConstructor(org.keycloak.models.IdentityProviderModel.class);
       useNewApi = true;
-      log.infof("Using new BrokeredIdentityContext(IdentityProviderModel) constructor");
+      log.infof("Detected Modern BrokeredIdentityContext(IdentityProviderModel) constructor");
     } catch (NoSuchMethodException e) {
       try {
+        // Keycloak 22 and older
         constructor = BrokeredIdentityContext.class.getConstructor(String.class);
-        log.infof("Using old BrokeredIdentityContext(String) constructor");
-
-        try {
-          setIdpConfigMethod = BrokeredIdentityContext.class.getMethod("setIdpConfig",
-            OAuth2IdentityProviderConfig.class);
-        } catch (NoSuchMethodException ex) {}
+        log.infof("Detected Legacy BrokeredIdentityContext(String) constructor");
       } catch (NoSuchMethodException ex) {
         throw new RuntimeException("Could not find any compatible BrokeredIdentityContext constructor", ex);
       }
     }
 
-    // Try to find the setIdp method (it exists in old versions, gone in new ones)
+    // Detect setIdpConfig(IdentityProviderModel)
     try {
-      setIdpMethod = BrokeredIdentityContext.class.getMethod("setIdp",
-        org.keycloak.broker.provider.IdentityProvider.class);
-      log.infof("setIdp(IdentityProvider) method available");
+      setIdpConfigMethod = BrokeredIdentityContext.class.getMethod("setIdpConfig", org.keycloak.models.IdentityProviderModel.class);
+      log.infof("Detected setIdpConfig(IdentityProviderModel) method");
     } catch (NoSuchMethodException e) {
-      log.infof("setIdp(IdentityProvider) method NOT available (Modern Keycloak)");
+      log.infof("setIdpConfig method NOT available on this Keycloak version");
+    }
+
+    // Detect setIdp(IdentityProvider) - Was removed in v25.
+    try {
+      setIdpMethod = BrokeredIdentityContext.class.getMethod("setIdp", org.keycloak.broker.provider.IdentityProvider.class);
+      log.infof("Detected setIdp(IdentityProvider) method");
+    } catch (NoSuchMethodException e) {
+      log.infof("setIdp method NOT available (Modern Keycloak logic applies)");
     }
 
     USE_NEW_CONTEXT_API = useNewApi;
@@ -144,28 +148,23 @@ public abstract class GsisAbstractIdentityProvider
    * Older API: new BrokeredIdentityContext(String id) + setIdpConfig(config) Newer API: new
    * BrokeredIdentityContext(IdentityProviderModel) - no setIdpConfig
    */
-  private BrokeredIdentityContext createBrokeredIdentityContext(OAuth2IdentityProviderConfig config,
-      String username) {
+  private BrokeredIdentityContext createBrokeredIdentityContext(OAuth2IdentityProviderConfig config, String username) {
     try {
       BrokeredIdentityContext context;
-
       if (USE_NEW_CONTEXT_API) {
-        // New API: BrokeredIdentityContext(IdentityProviderModel)
         context = (BrokeredIdentityContext) CONTEXT_CONSTRUCTOR.newInstance(config);
       } else {
-        // Old API: BrokeredIdentityContext(String)
         context = (BrokeredIdentityContext) CONTEXT_CONSTRUCTOR.newInstance(username);
+      }
 
-        // Call setIdpConfig if the method exists
-        if (SET_IDP_CONFIG_METHOD != null) {
-          SET_IDP_CONFIG_METHOD.invoke(context, config);
-        }
+      // Use the reflected method to avoid signature mismatches
+      if (SET_IDP_CONFIG_METHOD != null) {
+        SET_IDP_CONFIG_METHOD.invoke(context, config);
       }
 
       return context;
     } catch (Exception e) {
-      throw new RuntimeException(
-          "Failed to create BrokeredIdentityContext for username: " + username, e);
+      throw new RuntimeException("Failed to create context via reflection", e);
     }
   }
 
@@ -180,7 +179,6 @@ public abstract class GsisAbstractIdentityProvider
     BrokeredIdentityContext user = createBrokeredIdentityContext(config, username);
 
     user.setId(username);
-
     user.setUsername(username);
     user.setFirstName(firstname);
     user.setLastName(lastname);

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/SimpleHttpAdapter.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/SimpleHttpAdapter.java
@@ -26,35 +26,43 @@ import lombok.extern.jbosslog.JBossLog;
  * Older API (Keycloak <= 22.x): - org.keycloak.broker.provider.util.SimpleHttp - static
  * doGet/doPost methods returning SimpleHttp
  *
- * Newer API (Keycloak >= 24.x): - org.keycloak.http.simple.SimpleHttpRequest - static get/post
- * methods returning SimpleHttpRequest
+ * Newer API (Keycloak >= 24.x): - org.keycloak.http.simple.SimpleHttp - static get/post
+ * methods returning SimpleHttp
  */
 @JBossLog
 public class SimpleHttpAdapter {
 
   private static final String OLD_CLASS = "org.keycloak.broker.provider.util.SimpleHttp";
-  private static final String NEW_CLASS = "org.keycloak.http.simple.SimpleHttpRequest";
+  private static final String NEW_CLASS = "org.keycloak.http.simple.SimpleHttp";
 
   private static Class<?> httpClass;
+  private static Method factoryMethod; // For new API: SimpleHttp.create(session)
   private static Method getMethod;
   private static Method postMethod;
+  private static boolean isNewApi = false;
 
   static {
     // Detect API version once at class load time
     try {
+      // Try New API (Keycloak 24+)
       httpClass = Class.forName(NEW_CLASS);
-      log.infof("Using new SimpleHttpRequest API from %s", NEW_CLASS);
-      // Cache method references for new API
-      getMethod = httpClass.getMethod("get", String.class, KeycloakSession.class);
-      postMethod = httpClass.getMethod("post", String.class, KeycloakSession.class);
+      log.infof("Detected New SimpleHttp API at %s", NEW_CLASS);
+
+      // New API uses: SimpleHttp.create(session).doGet(url)
+      factoryMethod = httpClass.getMethod("create", KeycloakSession.class);
+      getMethod = httpClass.getMethod("doGet", String.class);
+      postMethod = httpClass.getMethod("doPost", String.class);
+      isNewApi = true;
     } catch (ClassNotFoundException e) {
       // Fall back to old API
       try {
         httpClass = Class.forName(OLD_CLASS);
-        log.infof("Using old SimpleHttp API from %s", OLD_CLASS);
-        // Cache method references for old API
+        log.infof("Detected Old SimpleHttp API at %s", OLD_CLASS);
+
+        // Old API uses: SimpleHttp.doGet(url, session)
         getMethod = httpClass.getMethod("doGet", String.class, KeycloakSession.class);
         postMethod = httpClass.getMethod("doPost", String.class, KeycloakSession.class);
+        isNewApi = false;
       } catch (ClassNotFoundException | NoSuchMethodException ex) {
         throw new RuntimeException("Could not find SimpleHttp API class or methods", ex);
       }
@@ -72,7 +80,14 @@ public class SimpleHttpAdapter {
    */
   public static Object doGet(String url, KeycloakSession session) {
     try {
-      return getMethod.invoke(null, url, session);
+      if (isNewApi) {
+        // Instance method call: SimpleHttp.create(session).doGet(url)
+        Object instance = factoryMethod.invoke(null, session);
+        return getMethod.invoke(instance, url);
+      } else {
+        // Static method call: SimpleHttp.doGet(url, session)
+        return getMethod.invoke(null, url, session);
+      }
     } catch (Exception e) {
       throw new RuntimeException("Failed to create GET request for URL: " + url, e);
     }
@@ -87,7 +102,12 @@ public class SimpleHttpAdapter {
    */
   public static Object doPost(String url, KeycloakSession session) {
     try {
-      return postMethod.invoke(null, url, session);
+      if (isNewApi) {
+        Object instance = factoryMethod.invoke(null, session);
+        return postMethod.invoke(instance, url);
+      } else {
+        return postMethod.invoke(null, url, session);
+      }
     } catch (Exception e) {
       throw new RuntimeException("Failed to create POST request for URL: " + url, e);
     }

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/SimpleHttpAdapter.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/SimpleHttpAdapter.java
@@ -46,7 +46,7 @@ public class SimpleHttpAdapter {
     try {
       // Try New API (Keycloak 24+)
       httpClass = Class.forName(NEW_CLASS);
-      log.infof("Detected New SimpleHttp API at %s", NEW_CLASS);
+      log.infof("Using new SimpleHttp API at %s", NEW_CLASS);
 
       // New API uses: SimpleHttp.create(session).doGet(url)
       factoryMethod = httpClass.getMethod("create", KeycloakSession.class);
@@ -57,7 +57,7 @@ public class SimpleHttpAdapter {
       // Fall back to old API
       try {
         httpClass = Class.forName(OLD_CLASS);
-        log.infof("Detected Old SimpleHttp API at %s", OLD_CLASS);
+        log.infof("Using old SimpleHttp API at %s", OLD_CLASS);
 
         // Old API uses: SimpleHttp.doGet(url, session)
         getMethod = httpClass.getMethod("doGet", String.class, KeycloakSession.class);

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/resource/GsisLogoutResource.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/resource/GsisLogoutResource.java
@@ -36,6 +36,7 @@ public class GsisLogoutResource {
       EventBuilder event = new EventBuilder(realm, session, session.getContext().getConnection());
       event.event(EventType.LOGOUT);
       event.error(Errors.USER_SESSION_NOT_FOUND);
+
       return ErrorPage.error(session, null, Response.Status.BAD_REQUEST,
           Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
     }
@@ -46,15 +47,17 @@ public class GsisLogoutResource {
       EventBuilder event = new EventBuilder(realm, session, session.getContext().getConnection());
       event.event(EventType.LOGOUT);
       event.error(Errors.USER_SESSION_NOT_FOUND);
+
       return ErrorPage.error(session, null, Response.Status.BAD_REQUEST,
           Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
     }
 
     if (userSession.getState() != UserSessionModel.State.LOGGING_OUT) {
-      log.error("User session in different state");
+      log.error("usersession in different state");
       EventBuilder event = new EventBuilder(realm, session, session.getContext().getConnection());
       event.event(EventType.LOGOUT);
       event.error(Errors.USER_SESSION_NOT_FOUND);
+
       return ErrorPage.error(session, null, Response.Status.BAD_REQUEST,
           Messages.SESSION_NOT_ACTIVE);
     }

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/resource/GsisLogoutResource.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/resource/GsisLogoutResource.java
@@ -1,0 +1,66 @@
+package gr.cti.nts.keycloak.idp.social.gsis.resource;
+
+import org.keycloak.events.Errors;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.services.ErrorPage;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.messages.Messages;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.jbosslog.JBossLog;
+
+@JBossLog
+public class GsisLogoutResource {
+
+  public static final String LOGOUT_RESPONSE_PATH = "response";
+
+  private final KeycloakSession session;
+
+  public GsisLogoutResource(KeycloakSession session) {
+    this.session = session;
+  }
+
+  @GET
+  @Path(LOGOUT_RESPONSE_PATH)
+  public Response handleLogoutResponse(@QueryParam("state") String state) {
+    RealmModel realm = session.getContext().getRealm();
+
+    if (state == null) {
+      log.error("No state parameter returned");
+      EventBuilder event = new EventBuilder(realm, session, session.getContext().getConnection());
+      event.event(EventType.LOGOUT);
+      event.error(Errors.USER_SESSION_NOT_FOUND);
+      return ErrorPage.error(session, null, Response.Status.BAD_REQUEST,
+          Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
+    }
+
+    UserSessionModel userSession = session.sessions().getUserSession(realm, state);
+    if (userSession == null) {
+      log.error("no valid user session");
+      EventBuilder event = new EventBuilder(realm, session, session.getContext().getConnection());
+      event.event(EventType.LOGOUT);
+      event.error(Errors.USER_SESSION_NOT_FOUND);
+      return ErrorPage.error(session, null, Response.Status.BAD_REQUEST,
+          Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
+    }
+
+    if (userSession.getState() != UserSessionModel.State.LOGGING_OUT) {
+      log.error("User session in different state");
+      EventBuilder event = new EventBuilder(realm, session, session.getContext().getConnection());
+      event.event(EventType.LOGOUT);
+      event.error(Errors.USER_SESSION_NOT_FOUND);
+      return ErrorPage.error(session, null, Response.Status.BAD_REQUEST,
+          Messages.SESSION_NOT_ACTIVE);
+    }
+
+    return AuthenticationManager.finishBrowserLogout(session, realm, userSession,
+        session.getContext().getUri(), session.getContext().getConnection(),
+        session.getContext().getRequestHeaders());
+  }
+}

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/resource/GsisLogoutResourceProvider.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/resource/GsisLogoutResourceProvider.java
@@ -1,0 +1,21 @@
+package gr.cti.nts.keycloak.idp.social.gsis.resource;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.resource.RealmResourceProvider;
+
+public class GsisLogoutResourceProvider implements RealmResourceProvider {
+
+  private final KeycloakSession session;
+
+  public GsisLogoutResourceProvider(KeycloakSession session) {
+    this.session = session;
+  }
+
+  @Override
+  public Object getResource() {
+    return new GsisLogoutResource(session);
+  }
+
+  @Override
+  public void close() {}
+}

--- a/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/resource/GsisLogoutResourceProviderFactory.java
+++ b/src/main/java/gr/cti/nts/keycloak/idp/social/gsis/resource/GsisLogoutResourceProviderFactory.java
@@ -1,0 +1,33 @@
+package gr.cti.nts.keycloak.idp.social.gsis.resource;
+
+import com.google.auto.service.AutoService;
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.services.resource.RealmResourceProvider;
+import org.keycloak.services.resource.RealmResourceProviderFactory;
+
+@AutoService(RealmResourceProviderFactory.class)
+public class GsisLogoutResourceProviderFactory implements RealmResourceProviderFactory {
+
+  public static final String ID = "gsis-logout";
+
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  @Override
+  public RealmResourceProvider create(KeycloakSession session) {
+    return new GsisLogoutResourceProvider(session);
+  }
+
+  @Override
+  public void init(Config.Scope config) {}
+
+  @Override
+  public void postInit(KeycloakSessionFactory factory) {}
+
+  @Override
+  public void close() {}
+}


### PR DESCRIPTION
## Changes

- Applied changes for providers to work in Keycloak 26
- Applied "code branching" to maintain functionality with Keycloak 22
- Replaced `"logout_response"` endpoint with a new resource

## Test cases

These changes have been tested using the `gsis-govuser-test` provider in 2 different instances of Keycloak using the [quay.io/keycloak/keycloak](https://quay.io/repository/keycloak/keycloak) docker image.

Versions used:

- `26.6`
- `22.0`

## Related issues

closes #73, closes #41, closes #120